### PR TITLE
docs: align README with KV-outer caching and legacy CuTe path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Python package; the public `fmha_sm100` / `fmha_sm100_plan` API is unchanged.
 
 > **Note:** `docs/architecture.png` predates the KV-outer integration and shows the
 > original two-stack layout. On this branch, sparse prefill is routed through
-> KV-outer (GQA ≥ 8) or legacy CuTe (GQA &lt; 8) via `sparse_fmha_adapter.py`.
+> KV-outer (GQA ≥ 8) or original MiniMax MSA CuTe (GQA &lt; 8) via `sparse_fmha_adapter.py`.
 
 > Algorithm reference: [MiniMax Sparse Attention paper](docs/MiniMaxSparseAttention.pdf).
 
@@ -29,8 +29,8 @@ Python package; the public `fmha_sm100` / `fmha_sm100_plan` API is unchanged.
 |---|---|---|
 | **csrc JIT** | `python/fmha_sm100/csrc/` | Dense FMHA (`fmha_sm100`, `fmha_sm100_plan`) + `sparse_topk_select` indexer, compiled from Jinja templates by `jit.py` at runtime. |
 | **KV-outer** | `python/fmha_sm100/kvouter/` + `csrc/kvouter/` | Fireworks KV-outer sparse **prefill** (GQA ≥ 8): Python CuTe-DSL + optional C++ AOT extension (`fmha_sm100._C`). Default path when `qhead_per_kv ≥ 8`. |
-| **CuTe-DSL (legacy sparse)** | `python/fmha_sm100/cute/` | CSR sparse prefill fallback (GQA &lt; 8), paged FP8 decode, BF16 / FP8 / NVFP4 / FP4 paths, compiled at runtime via `cute.compile`. |
-| **Bridge** | `python/fmha_sm100/sparse_fmha_adapter.py` | Routes sparse prefill through KV-outer or legacy CuTe based on GQA ratio; adapts the `fmha_sm100` API to both backends. |
+| **original MiniMax MSA CuTe-DSL** | `python/fmha_sm100/cute/` | CSR sparse prefill fallback (GQA &lt; 8), paged FP8 decode, BF16 / FP8 / NVFP4 / FP4 paths, compiled at runtime via `cute.compile`. |
+| **Bridge** | `python/fmha_sm100/sparse_fmha_adapter.py` | Routes sparse prefill through KV-outer or original MiniMax MSA CuTe based on GQA ratio; adapts the `fmha_sm100` API to both backends. |
 
 > **License: MIT.** Self-authored files carry `SPDX-License-Identifier: MIT`.
 > See [LICENSE](LICENSE) and [NOTICE](NOTICE). Bundled / derived third-party
@@ -39,7 +39,7 @@ Python package; the public `fmha_sm100` / `fmha_sm100_plan` API is unchanged.
 ## Requirements
 
 - **GPU**: NVIDIA SM100 (Blackwell).
-- **Toolchain**: CUDA Toolkit **13.x** with `nvcc` on `PATH` (or `CUDA_HOME` / `CUDA_PATH` set). Required for all stacks (csrc JIT, KV-outer, legacy CuTe).
+- **Toolchain**: CUDA Toolkit **13.x** with `nvcc` on `PATH` (or `CUDA_HOME` / `CUDA_PATH` set). Required for all stacks (csrc JIT, KV-outer, original MiniMax MSA CuTe).
 - **Python**: ≥ 3.10.
 - **PyTorch**: ≥ 2.9 (see `pyproject.toml`).
 - **OS**: Linux x86_64 (aarch64 untested; JIT builds may need small Makefile edits on WSL).
@@ -107,7 +107,7 @@ restarts.
 | `MINIMAX_KERNELS_CUTE_AOT_CACHE` | Persistent directory for KV-outer CuTe-DSL AOT exports (default: per-process temp dir) |
 
 Sparse prefill uses KV-outer when `num_qo_heads // num_kv_heads ≥ 8` (e.g. TP1
-config 64/4); lower GQA ratios still use the legacy CuTe CSR path under `cute/`.
+config 64/4); lower GQA ratios still use the original MiniMax MSA CuTe CSR path under `cute/`.
 
 ## Verify
 
@@ -167,7 +167,7 @@ out, _ = fmha_sm100(
 ```
 
 For block-sparse prefill with CSR metadata, NVFP4 K/V, and the paged FP8 decode
-wrapper, see the **legacy CuTe-DSL deep dive** (still used for decode, NVFP4, and
+wrapper, see the **original MiniMax MSA CuTe-DSL deep dive** (still used for decode, NVFP4, and
 GQA &lt; 8 prefill):
 
 - [`python/fmha_sm100/cute/README.md`](python/fmha_sm100/cute/README.md)
@@ -230,13 +230,13 @@ python/fmha_sm100/                  Python package
   api.py                            fmha_sm100 / fmha_sm100_plan / sparse_topk_select
   jit.py                            Runtime JIT (nvcc + ninja) for the csrc stack
   sparse.py                         Lazy shim that loads the cute/ stack
-  sparse_fmha_adapter.py            Bridge: fmha_sm100 API → KV-outer or legacy CuTe
+  sparse_fmha_adapter.py            Bridge: fmha_sm100 API → KV-outer or original MiniMax MSA CuTe
   kvouter/                          Vendored Fireworks KV-outer (Python + AOT export)
   csrc/kvouter/                     KV-outer C++ op (fmha_sm100._C)
   csrc/                             Dense CUDA kernels + Jinja templates (JIT-compiled)
     include/                        Vendored FlashInfer / CUTLASS-derived / TRT-LLM headers
   cutlass/                          NVIDIA CUTLASS git submodule (include/ + tools/util/include/)
-  cute/                             Legacy CuTe-DSL sparse attention (loaded via sys.path)
+  cute/                             Original MiniMax MSA CuTe-DSL sparse attention (loaded via sys.path)
 setup.py                            Builds fmha_sm100._C CUDA extension
 tests/                              Correctness tests
   smoke/  integration/  regression/
@@ -256,13 +256,13 @@ benchmarks/                         bench_sparse_attention_ops.py
   for background. Index build + forward + combine; C++ AOT path preferred
   (`fmha_sm100._C`). Public entry: `sparse_fmha` → `kvouter_attention`
   (via `sparse_fmha_adapter`).
-- **CuTe-DSL (legacy sparse)** — CSR sparse prefill fallback (GQA &lt; 8),
+- **original MiniMax MSA CuTe-DSL** — CSR sparse prefill fallback (GQA &lt; 8),
   FP8 / NVFP4 / FP4 quantization, paged FP8 decode
   (`SparseDecodePagedAttentionWrapper`), FP4 block-score indexer.
   Public entry: `fmha_sm100.sparse_atten_func`,
   `fmha_sm100.sparse_decode_atten_func`, `fmha_sm100.fp4_indexer_block_scores`.
 - **Bridge** — `sparse_fmha_plan` / `sparse_fmha` adapt the dense-API call
-  site to KV-outer or legacy CuTe for prefill; decode and indexer paths are
+  site to KV-outer or original MiniMax MSA CuTe for prefill; decode and indexer paths are
   unchanged.
 
 ## Third-party licenses

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Python package; the public `fmha_sm100` / `fmha_sm100_plan` API is unchanged.
 
 ![MSA architecture](docs/architecture.png)
 
+> **Note:** `docs/architecture.png` predates the KV-outer integration and shows the
+> original two-stack layout. On this branch, sparse prefill is routed through
+> KV-outer (GQA ≥ 8) or legacy CuTe (GQA &lt; 8) via `sparse_fmha_adapter.py`.
+
 > Algorithm reference: [MiniMax Sparse Attention paper](docs/MiniMaxSparseAttention.pdf).
 
 | Stack | Path | What it gives you |
@@ -51,7 +55,11 @@ python -c "import torch; print(torch.__version__)"                # ≥ 2.9
 
 ## Using with the `kernels` library
 
-To quickly get started using MSA kernels, you can use the [`kernels` library](https://github.com/huggingface/kernels):
+> **Note:** The Hugging Face Hub build tracks upstream `main` and does not include
+> the Fireworks KV-outer backend on this branch. For KV-outer sparse prefill,
+> install from the `fireworks-msa` branch (see [Install](#install)).
+
+To quickly get started using upstream MSA kernels, you can use the [`kernels` library](https://github.com/huggingface/kernels):
 
 ```py
 # make sure `kernels` is installed: `pip install -U kernels`
@@ -81,9 +89,12 @@ pip install . --no-build-isolation      # standard install
 ```
 
 This pulls in `nvidia-cutlass-dsl`, `quack-kernels`, and `flash-attn-4` (see
-`pyproject.toml`). Dense csrc kernels are JIT-compiled on first use; the KV-outer
-C++ extension is built at install time. On first KV-outer call per config, CuTe-DSL
-kernels are AOT-exported (cached under `~/.cache/minfer/`).
+`pyproject.toml`). Dense csrc kernels are JIT-compiled on first use and cached
+under `~/.cache/minfer/fmha_sm100/` (delete that directory to force recompile).
+The KV-outer C++ extension is built at install time. On the first KV-outer call
+per config, CuTe-DSL kernels are AOT-exported into a per-process temp directory;
+set `MINIMAX_KERNELS_CUTE_AOT_CACHE` to a fixed path to persist that cache across
+restarts.
 
 **KV-outer backend selection** (optional env vars):
 
@@ -93,21 +104,24 @@ kernels are AOT-exported (cached under `~/.cache/minfer/`).
 | `FMHA_SM100_KVOUTER_CPP=1` | Force C++ AOT |
 | `FMHA_SM100_KVOUTER_CPP=0` | Force Python CuTe-DSL |
 | `MINIMAX_KERNELS_KVOUTER_CPP` | Legacy alias for the same flags |
+| `MINIMAX_KERNELS_CUTE_AOT_CACHE` | Persistent directory for KV-outer CuTe-DSL AOT exports (default: per-process temp dir) |
 
 Sparse prefill uses KV-outer when `num_qo_heads // num_kv_heads ≥ 8` (e.g. TP1
 config 64/4); lower GQA ratios still use the legacy CuTe CSR path under `cute/`.
 
 ## Verify
 
-Run a small CUDA smoke test. **The first run JIT-compiles `sparse_topk_select`,
-which takes 30 s – a few minutes on a cold nvcc cache** — this is normal, not
-a hang. The KV-outer C++ extension (`fmha_sm100._C`) is built at `pip install`
-time; the first sparse prefill call may additionally AOT-export CuTe-DSL kernels
-(cached under `~/.cache/minfer/`). Subsequent runs hit the caches and finish
-in seconds.
+Run small CUDA smoke tests after install:
 
 ```bash
+# Dense indexer JIT (first run compiles sparse_topk_select; 30 s – a few minutes
+# on a cold nvcc cache is normal, not a hang). Cached under ~/.cache/minfer/fmha_sm100/.
 python tests/smoke/test_sparse_topk_forced.py
+
+# End-to-end sparse prefill via the fmha_sm100 API (exercises KV-outer when
+# qhead_per_kv >= 8; default h_r_real=8). First call may AOT-export CuTe-DSL
+# kernels into a per-process temp dir (or MINIMAX_KERNELS_CUTE_AOT_CACHE).
+python tests/smoke/test_proxy_kv_smoke.py
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fmha_sm100"
 version = "0.1.1"
-description = "MSA — MiniMax Sparse Attention: dense FlashAttention + sparse top-k indexer (csrc JIT) and CuTe-DSL sparse attention for NVIDIA SM100 (CUDA 13.x required)"
+description = "MSA — MiniMax Sparse Attention: dense FlashAttention + sparse top-k indexer (csrc JIT), Fireworks KV-outer sparse prefill, and legacy CuTe-DSL sparse attention for NVIDIA SM100 (CUDA 13.x required)"
 readme = "README.md"
 requires-python = ">=3.10"
 # SPDX-License-Identifier: MIT
@@ -30,14 +30,17 @@ dependencies = [
 
 [project.urls]
 
-# The Python package lives under python/. Both kernel stacks ship as package
-# data and work from both editable and wheel installs:
+# The Python package lives under python/. All kernel stacks ship as package data
+# and work from both editable and wheel installs:
 #   * Dense csrc/ kernels are JIT-compiled at runtime (python/fmha_sm100/jit.py).
 #     The CUDA sources, Jinja templates, and vendored CUTLASS headers live inside
 #     the package directory so that JIT can locate them via __file__.
-#   * The CuTe-DSL sparse stack (python/fmha_sm100/cute/) is exposed through the
-#     importable `fmha_sm100.sparse` module (and lazily from the package root),
-#     which adds that directory to sys.path and re-exports the public sparse API.
+#   * KV-outer (python/fmha_sm100/kvouter/ + csrc/kvouter/) is built as
+#     fmha_sm100._C at install time and routes sparse prefill for GQA >= 8.
+#   * The legacy CuTe-DSL sparse stack (python/fmha_sm100/cute/) is exposed
+#     through the importable `fmha_sm100.sparse` module (and lazily from the
+#     package root), which adds that directory to sys.path and re-exports the
+#     public sparse API.
 [tool.setuptools]
 package-dir = { "" = "python" }
 # The cute/ sparse sources are loaded via sys.path.insert at runtime by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "fmha_sm100"
 version = "0.1.1"
-description = "MSA — MiniMax Sparse Attention: dense FlashAttention + sparse top-k indexer (csrc JIT), Fireworks KV-outer sparse prefill, and legacy CuTe-DSL sparse attention for NVIDIA SM100 (CUDA 13.x required)"
+description = "MSA — MiniMax Sparse Attention: dense FlashAttention + sparse top-k indexer (csrc JIT), Fireworks KV-outer sparse prefill, and original MiniMax MSA CuTe-DSL sparse attention for NVIDIA SM100 (CUDA 13.x required)"
 readme = "README.md"
 requires-python = ">=3.10"
 # SPDX-License-Identifier: MIT
@@ -37,7 +37,7 @@ dependencies = [
 #     the package directory so that JIT can locate them via __file__.
 #   * KV-outer (python/fmha_sm100/kvouter/ + csrc/kvouter/) is built as
 #     fmha_sm100._C at install time and routes sparse prefill for GQA >= 8.
-#   * The legacy CuTe-DSL sparse stack (python/fmha_sm100/cute/) is exposed
+#   * The original MiniMax MSA CuTe-DSL sparse stack (python/fmha_sm100/cute/) is exposed
 #     through the importable `fmha_sm100.sparse` module (and lazily from the
 #     package root), which adds that directory to sys.path and re-exports the
 #     public sparse API.

--- a/python/fmha_sm100/cute/README.md
+++ b/python/fmha_sm100/cute/README.md
@@ -1,6 +1,6 @@
-# MiniMax Sparse Attention (MSA) — legacy CuTe-DSL sparse stack
+# MiniMax Sparse Attention (MSA) — original MiniMax MSA CuTe-DSL sparse stack
 
-This is the **legacy CuTe-DSL** sparse implementation, shipped inside the
+This is the **original MiniMax MSA CuTe-DSL** sparse implementation, shipped inside the
 `fmha_sm100` Python package. On the `fireworks-msa` branch, sparse **prefill**
 with `qhead_per_kv >= 8` is routed to the Fireworks KV-outer backend instead;
 this stack remains the path for GQA &lt; 8 prefill, paged FP8 decode, NVFP4 /
@@ -8,7 +8,7 @@ FP4 quantization, and the FP4 indexer. For the package overview, install
 steps, and the dense csrc JIT path, see the
 [top-level README](../../../../README.md).
 
-The rest of this file documents the **legacy CuTe-DSL sparse** surface only:
+The rest of this file documents the **original MiniMax MSA CuTe-DSL sparse** surface only:
 CSR metadata, schedules, sparse page attention, FP8 / NVFP4 / FP4 quantization,
 the paged FP8 decode wrapper, and the FP4 indexer.
 

--- a/python/fmha_sm100/cute/README.md
+++ b/python/fmha_sm100/cute/README.md
@@ -1,12 +1,15 @@
-# MiniMax Sparse Attention (MSA) — CuTe-DSL kernel
+# MiniMax Sparse Attention (MSA) — legacy CuTe-DSL sparse stack
 
-This is the **CuTe-DSL** implementation of MSA, shipped inside the
-`fmha_sm100` Python package. For the package overview, install steps, and
-the dense csrc JIT path, see the
+This is the **legacy CuTe-DSL** sparse implementation, shipped inside the
+`fmha_sm100` Python package. On the `fireworks-msa` branch, sparse **prefill**
+with `qhead_per_kv >= 8` is routed to the Fireworks KV-outer backend instead;
+this stack remains the path for GQA &lt; 8 prefill, paged FP8 decode, NVFP4 /
+FP4 quantization, and the FP4 indexer. For the package overview, install
+steps, and the dense csrc JIT path, see the
 [top-level README](../../../../README.md).
 
-The rest of this file documents the **sparse (CuTe-DSL)** surface only: CSR
-metadata, schedules, sparse page attention, FP8 / NVFP4 / FP4 quantization,
+The rest of this file documents the **legacy CuTe-DSL sparse** surface only:
+CSR metadata, schedules, sparse page attention, FP8 / NVFP4 / FP4 quantization,
 the paged FP8 decode wrapper, and the FP4 indexer.
 
 ---
@@ -43,14 +46,21 @@ The current public support contract is intentionally narrow:
 
 ## Installation
 
-Install a CUDA-enabled PyTorch build that matches your environment first. This
-stack requires **CUDA Toolkit 13.x** (`nvcc`); see the
-[top-level README](../../../../README.md#requirements). Then install the
-repo-side Python requirements:
+Install the package from the repo root first (see
+[top-level README — Install](../../../../README.md#install)):
+
+```bash
+pip install -e . --no-build-isolation
+```
+
+For CuTe-DSL-only development inside this directory, you can additionally run:
 
 ```bash
 make setup
 ```
+
+This stack requires **CUDA Toolkit 13.x** (`nvcc`); see the
+[top-level README — Requirements](../../../../README.md#requirements).
 
 ## Quick Start
 
@@ -684,7 +694,8 @@ High-signal files:
 - `D=128` is the only documented and tested head dimension in the current contract.
 - The FP4 indexer currently returns block max scores only; topK selection and
   CSR construction remain caller-owned downstream steps.
-- This repo is not packaged as a pip module yet; it is used directly from the source tree.
+- Prefer `pip install -e . --no-build-isolation` from the repo root; `make setup`
+  in this directory is for CuTe-DSL-only development.
 - Paged FP8 decode currently requires `qhead_per_kv=16`, `page_size=128`, and SM100. Other configurations are not supported by the schedule kernel.
 - Paged FP8 decode `batch <= 1024`. The single-CTA schedule kernel stores per-batch state in shared memory; larger batches need a multi-CTA cooperative redesign (planned but not yet implemented).
 - Paged FP8 decode requires `seqused_k[b] >= seqlen_q` for every batch (i.e. context must include the q-tokens being emitted — a batched-decode invariant), AND `seqused_k[b] % page_size ∈ {0, seqlen_q, 2·seqlen_q, ..., page_size − seqlen_q}` (the last partial page must hold a whole packed-GQA q-group, which is `seqlen_q` columns). Violations are caught at `plan()` with a clear `ValueError`. The same constraint exists in FA-style packgqa kernels in principle but never fires there because FA's typical use satisfies `seqlen_k ≥ seqlen_q` (decode emits 1 token; prefill is self-attention). Tracked as a kernel-level TODO (saturate `causal_col_limit ≥ 1` in mask.py).


### PR DESCRIPTION
## Summary
- Fix KV-outer AOT cache documentation: default is a per-process temp dir; `MINIMAX_KERNELS_CUTE_AOT_CACHE` enables persistence. Dense csrc JIT cache stays under `~/.cache/minfer/fmha_sm100/`.
- Expand **Verify** with `tests/smoke/test_proxy_kv_smoke.py` for the KV-outer E2E path.
- Note that `docs/architecture.png` predates KV-outer integration and that Hugging Face Hub `kernels` builds track upstream `main`.
- Refresh `pyproject.toml` description/comments and mark `python/fmha_sm100/cute/README.md` as the legacy CuTe stack (GQA < 8 prefill, decode, NVFP4, indexer).

## Test plan
- [x] Doc-only change; reviewed against `jit.py`, `aot_export.py`, and smoke test layout on `fireworks-msa`

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MSA/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787782903&installation_model_id=427615&pr_number=10&repository=MiniMax-AI%2FMSA&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMSA%2Fpull%2F10&signature=a9093f7f05c2d1b4b18227e291e3c3bdcdb44d1526a697ac5d78e7f87f768275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->